### PR TITLE
Issues with using python 3.6

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
 - pip=9.0.1=py36_1
 - pyparsing=2.1.4=py36_0
 - pyqt=5.6.0=py36_2
-- python=3.6.1=0
+- python=3.5.4=0
 - python-dateutil=2.6.0=py36_0
 - pytz=2017.2=py36_0
 - pyyaml=3.12=py36_0


### PR DESCRIPTION
>> ./test_yolo.py model_data/yolo.h5

name: GeForce GTX 1070
major: 6 minor: 1 memoryClockRate (GHz) 1.683
pciBusID 0000:01:00.0
Total memory: 7.92GiB
Free memory: 7.32GiB
I tensorflow/core/common_runtime/gpu/gpu_device.cc:906] DMA: 0 
I tensorflow/core/common_runtime/gpu/gpu_device.cc:916] 0:   Y 
I tensorflow/core/common_runtime/gpu/gpu_device.cc:975] Creating TensorFlow device (/gpu:0) -> (device: 0, name: GeForce GTX 1070, pci bus id: 0000:01:00.0)
/home/dhingratul/anaconda2/envs/yad2k/lib/python3.6/site-packages/keras/models.py:248: UserWarning: No training configuration found in save file: the model was *not* compiled. Compile it manually.
  warnings.warn('No training configuration found in save file: '
model_data/yolo.h5 model, anchors, and classes loaded.
F tensorflow/stream_executor/cuda/cuda_dnn.cc:222] Check failed: s.ok() could not find cudnnCreate in cudnn DSO; dlerror: /home/dhingratul/anaconda2/envs/yad2k/lib/python3.6/site-packages/tensorflow/python/_pywrap_tensorflow.so: undefined symbol: cudnnCreate
Aborted (core dumped)
