### PR TITLE
Add tiny yolo model body, but cannot retrain

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -55,4 +55,4 @@ dependencies:
   - pydot-ng==1.0.0
   - tensorflow-gpu==1.0.1
   - theano==0.9.0
-prefix: /home/allan/anaconda3/envs/yad2k
+prefix: /Users/liangchuangu/anaconda3/envs/yad2k

--- a/retrain.sh
+++ b/retrain.sh
@@ -1,0 +1,1 @@
+python3 retrain_yolo.py --data_path "../DATA/my_dataset.npz" --classes_path "../DATA/gtsdb_classes.txt"

--- a/retrain_tiny_yolo.py
+++ b/retrain_tiny_yolo.py
@@ -1,0 +1,356 @@
+"""
+This is a script that can be used to retrain the YOLOv2 model for your own dataset.
+"""
+import argparse
+
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import PIL
+import tensorflow as tf
+from keras import backend as K
+from keras.layers import Input, Lambda, Conv2D
+from keras.models import load_model, Model
+from keras.callbacks import TensorBoard, ModelCheckpoint, EarlyStopping
+
+from yad2k.models.keras_yolo import (preprocess_true_boxes, tiny_yolo_body,
+                                     yolo_eval, yolo_head, yolo_loss)
+from yad2k.utils.draw_boxes import draw_boxes
+
+# Args
+argparser = argparse.ArgumentParser(
+    description="Retrain or 'fine-tune' a pretrained YOLOv2 model for your own data.")
+
+argparser.add_argument(
+    '-d',
+    '--data_path',
+    help="path to numpy data file (.npz) containing np.object array 'boxes' and np.uint8 array 'images'",
+    default=os.path.join('..', 'DATA', 'underwater_data.npz'))
+
+argparser.add_argument(
+    '-a',
+    '--anchors_path',
+    help='path to anchors file, defaults to yolo_anchors.txt',
+    default=os.path.join('model_data', 'yolo_anchors.txt'))
+
+argparser.add_argument(
+    '-c',
+    '--classes_path',
+    help='path to classes file, defaults to pascal_classes.txt',
+    default=os.path.join('..', 'DATA', 'underwater_classes.txt'))
+
+# Default anchor boxes
+YOLO_ANCHORS = np.array(
+    ((0.57273, 0.677385), (1.87446, 2.06253), (3.33843, 5.47434),
+     (7.88282, 3.52778), (9.77052, 9.16828)))
+
+def _main(args):
+    data_path = os.path.expanduser(args.data_path)
+    classes_path = os.path.expanduser(args.classes_path)
+    anchors_path = os.path.expanduser(args.anchors_path)
+
+    class_names = get_classes(classes_path)
+    anchors = get_anchors(anchors_path)
+
+    data = np.load(data_path) # custom data saved as a numpy file.
+    #  has 2 arrays: an object array 'boxes' (variable length of boxes in each image)
+    #  and an array of images 'images'
+
+    image_data, boxes = process_data(data['images'], data['boxes'])
+
+    anchors = YOLO_ANCHORS
+
+    detectors_mask, matching_true_boxes = get_detector_mask(boxes, anchors)
+
+    print('detectors_mask.shape: ', detectors_mask.shape)
+    print('matching_true_boxes.shape: ', matching_true_boxes.shape)
+    model_body, model = create_model(anchors, class_names)
+
+    train(
+        model,
+        class_names,
+        anchors,
+        image_data,
+        boxes,
+        detectors_mask,
+        matching_true_boxes
+    )
+
+    draw(model_body,
+        class_names,
+        anchors,
+        image_data,
+        image_set='val', # assumes training/validation split is 0.9
+        weights_name='tiny_trained_stage_3_best.h5',
+        save_all=False)
+
+
+def get_classes(classes_path):
+    '''loads the classes'''
+    with open(classes_path) as f:
+        class_names = f.readlines()
+    class_names = [c.strip() for c in class_names]
+    return class_names
+
+def get_anchors(anchors_path):
+    '''loads the anchors from a file'''
+    if os.path.isfile(anchors_path):
+        with open(anchors_path) as f:
+            anchors = f.readline()
+            anchors = [float(x) for x in anchors.split(',')]
+            return np.array(anchors).reshape(-1, 2)
+    else:
+        Warning("Could not open anchors file, using default.")
+        return YOLO_ANCHORS
+
+def process_data(images, boxes=None):
+    '''processes the data'''
+    images = [PIL.Image.fromarray(i) for i in images]
+    orig_size = np.array([images[0].width, images[0].height])
+    orig_size = np.expand_dims(orig_size, axis=0)
+
+    # Image preprocessing.
+    processed_images = [i.resize((416, 416), PIL.Image.BICUBIC) for i in images]
+    processed_images = [np.array(image, dtype=np.float) for image in processed_images]
+    processed_images = [image/255. for image in processed_images]
+
+    if boxes is not None:
+        # Box preprocessing.
+        # Original boxes stored as 1D list of class, x_min, y_min, x_max, y_max.
+        boxes = [box.reshape((-1, 5)) for box in boxes]
+        # Get extents as y_min, x_min, y_max, x_max, class for comparision with
+        # model output.
+        boxes_extents = [box[:, [2, 1, 4, 3, 0]] for box in boxes]
+
+        # Get box parameters as x_center, y_center, box_width, box_height, class.
+        boxes_xy = [0.5 * (box[:, 3:5] + box[:, 1:3]) for box in boxes]
+        boxes_wh = [box[:, 3:5] - box[:, 1:3] for box in boxes]
+        boxes_xy = [boxxy / orig_size for boxxy in boxes_xy]
+        boxes_wh = [boxwh / orig_size for boxwh in boxes_wh]
+        boxes = [np.concatenate((boxes_xy[i], boxes_wh[i], box[:, 0:1]), axis=1) for i, box in enumerate(boxes)]
+
+        # find the max number of boxes
+        max_boxes = 0
+        for boxz in boxes:
+            if boxz.shape[0] > max_boxes:
+                max_boxes = boxz.shape[0]
+
+        # add zero pad for training
+        for i, boxz in enumerate(boxes):
+            if boxz.shape[0]  < max_boxes:
+                zero_padding = np.zeros( (max_boxes-boxz.shape[0], 5), dtype=np.float32)
+                boxes[i] = np.vstack((boxz, zero_padding))
+
+        return np.array(processed_images), np.array(boxes)
+    else:
+        return np.array(processed_images)
+
+def get_detector_mask(boxes, anchors):
+    '''
+    Precompute detectors_mask and matching_true_boxes for training.
+    Detectors mask is 1 for each spatial position in the final conv layer and
+    anchor that should be active for the given boxes and 0 otherwise.
+    Matching true boxes gives the regression targets for the ground truth box
+    that caused a detector to be active or 0 otherwise.
+    '''
+    detectors_mask = [0 for i in range(len(boxes))]
+    matching_true_boxes = [0 for i in range(len(boxes))]
+    for i, box in enumerate(boxes):
+        detectors_mask[i], matching_true_boxes[i] = preprocess_true_boxes(box, anchors, [416, 416])
+
+    return np.array(detectors_mask), np.array(matching_true_boxes)
+
+def create_model(anchors, class_names, load_pretrained=True, freeze_body=True):
+    '''
+    returns the body of the model and the model
+
+    # Params:
+
+    load_pretrained: whether or not to load the pretrained model or initialize all weights
+
+    freeze_body: whether or not to freeze all weights except for the last layer's
+
+    # Returns:
+
+    model_body: YOLOv2 with new output layer
+
+    model: YOLOv2 with custom loss Lambda layer
+
+    '''
+
+    detectors_mask_shape = (13, 13, 5, 1)
+    matching_boxes_shape = (13, 13, 5, 5)
+
+    # Create model input layers.
+    image_input = Input(shape=(416, 416, 3))
+    boxes_input = Input(shape=(None, 5))
+    detectors_mask_input = Input(shape=detectors_mask_shape)
+    matching_boxes_input = Input(shape=matching_boxes_shape)
+
+    # Create model body.
+    yolo_model = tiny_yolo_body(image_input, len(anchors), len(class_names))
+    topless_yolo = Model(yolo_model.input, yolo_model.layers[-2].output)
+
+    if load_pretrained:
+        # Save topless yolo:
+        topless_yolo_path = os.path.join('model_data', 'tiny-yolo_topless.h5')
+        if not os.path.exists(topless_yolo_path):
+            print("CREATING TOPLESS WEIGHTS FILE")
+            yolo_path = os.path.join('model_data', 'tiny-yolo.h5')
+            model_body = load_model(yolo_path)
+            model_body = Model(model_body.inputs, model_body.layers[-2].output)
+            model_body.save_weights(topless_yolo_path)
+        topless_yolo.load_weights(topless_yolo_path)
+
+    if freeze_body:
+        for layer in topless_yolo.layers:
+            layer.trainable = False
+    final_layer = Conv2D(len(anchors)*(5+len(class_names)), (1, 1), activation='linear')(topless_yolo.output)
+
+    model_body = Model(image_input, final_layer)
+
+    # Place model loss on CPU to reduce GPU memory usage.
+    with tf.device('/cpu:0'):
+        # TODO: Replace Lambda with custom Keras layer for loss.
+        model_loss = Lambda(
+            yolo_loss,
+            output_shape=(1, ),
+            name='yolo_loss',
+            arguments={'anchors': anchors,
+                       'num_classes': len(class_names),
+                       'print_loss' : True})([
+                           model_body.output, boxes_input,
+                           detectors_mask_input, matching_boxes_input
+                       ])
+
+    model = Model(
+        [model_body.input, boxes_input, detectors_mask_input,
+         matching_boxes_input], model_loss)
+
+    return model_body, model
+
+def train(model, class_names, anchors, image_data, boxes, detectors_mask, matching_true_boxes, validation_split=0.1):
+    '''
+    retrain/fine-tune the model
+
+    logs training with tensorboard
+
+    saves training weights in current directory
+
+    best weights according to val_loss is saved as trained_stage_3_best.h5
+    '''
+    model.compile(
+        optimizer='adam', loss={
+            'yolo_loss': lambda y_true, y_pred: y_pred
+        })  # This is a hack to use the custom loss function in the last layer.
+
+
+    logging = TensorBoard()
+    checkpoint = ModelCheckpoint("tiny_trained_stage_3_best.h5", monitor='val_loss',
+                                 save_weights_only=True, save_best_only=True)
+    early_stopping = EarlyStopping(monitor='val_loss', min_delta=0, patience=15, verbose=1, mode='auto')
+
+    model.fit([image_data, boxes, detectors_mask, matching_true_boxes],
+              np.zeros(len(image_data)),
+              validation_split=validation_split,
+              batch_size=32,
+              epochs=5,
+              callbacks=[logging])
+    model.save_weights('tiny_trained_stage_1.h5')
+
+    model_body, model = create_model(anchors, class_names, load_pretrained=False, freeze_body=False)
+
+    model.load_weights('tiny_trained_stage_1.h5')
+
+    model.compile(
+        optimizer='adam', loss={
+            'yolo_loss': lambda y_true, y_pred: y_pred
+        })  # This is a hack to use the custom loss function in the last layer.
+
+
+    model.fit([image_data, boxes, detectors_mask, matching_true_boxes],
+              np.zeros(len(image_data)),
+              validation_split=validation_split,
+              batch_size=8,
+              epochs=30,
+              callbacks=[logging])
+
+    model.save_weights('tiny_trained_stage_2.h5')
+
+    #model.load_weights('trained_stage_3_best.h5')
+
+    model.fit([image_data, boxes, detectors_mask, matching_true_boxes],
+              np.zeros(len(image_data)),
+              validation_split=validation_split,
+              batch_size=32,
+              epochs=500,
+              callbacks=[logging, checkpoint, early_stopping])
+
+    model.save_weights('tiny_trained_stage_3.h5')
+
+def draw(model_body, class_names, anchors, image_data, image_set='val',
+            weights_name='tiny_trained_stage_3_best.h5', out_path="output_images", save_all=True):
+    '''
+    Draw bounding boxes on image data
+    '''
+    if image_set == 'train':
+        image_data = np.array([np.expand_dims(image, axis=0)
+            for image in image_data[:int(len(image_data)*.9)]])
+    elif image_set == 'val':
+        image_data = np.array([np.expand_dims(image, axis=0)
+            for image in image_data[int(len(image_data)*.9):]])
+    elif image_set == 'all':
+        image_data = np.array([np.expand_dims(image, axis=0)
+            for image in image_data])
+    else:
+        ValueError("draw argument image_set must be 'train', 'val', or 'all'")
+    # model.load_weights(weights_name)
+    print(image_data.shape)
+    model_body.load_weights(weights_name)
+
+
+    # Use to grnerate weights for test_yolo.py
+    print(model_body.summary())
+    model_body.save('{}'.format("retrained_tiny_yolo.h5"))
+    print('Saved Keras model to {}'.format("retrained_tiny_yolo.h5"))
+
+    # Create output variables for prediction.
+    yolo_outputs = yolo_head(model_body.output, anchors, len(class_names))
+    input_image_shape = K.placeholder(shape=(2, ))
+    boxes, scores, classes = yolo_eval(
+        yolo_outputs, input_image_shape, score_threshold=0.07, iou_threshold=0.0)
+
+    # Run prediction on overfit image.
+    sess = K.get_session()  # TODO: Remove dependence on Tensorflow session.
+
+    if  not os.path.exists(out_path):
+        os.makedirs(out_path)
+    for i in range(len(image_data)):
+        out_boxes, out_scores, out_classes = sess.run(
+            [boxes, scores, classes],
+            feed_dict={
+                model_body.input: image_data[i],
+                input_image_shape: [image_data.shape[2], image_data.shape[3]],
+                K.learning_phase(): 0
+            })
+        print('Found {} boxes for image.'.format(len(out_boxes)))
+        print(out_boxes)
+
+        # Plot image with predicted boxes.
+        image_with_boxes = draw_boxes(image_data[i][0], out_boxes, out_classes,
+                                    class_names, out_scores)
+        # Save the image:
+        if save_all or (len(out_boxes) > 0):
+            image = PIL.Image.fromarray(image_with_boxes)
+            image.save(os.path.join(out_path,str(i)+'.png'))
+
+        # To display (pauses the program):
+        # plt.imshow(image_with_boxes, interpolation='nearest')
+        # plt.show()
+
+
+
+if __name__ == '__main__':
+    args = argparser.parse_args()
+    _main(args)

--- a/test.sh
+++ b/test.sh
@@ -10,3 +10,5 @@ python3 test_yolo.py --anchors_path model_data/yolo_anchors.txt --classes_path .
 python3 test_yolo.py --anchors_path model_data/yolo_anchors.txt --classes_path model_data/coco_classes.txt --test_path /Users/liangchuangu/Downloads/TASS_jpgs --output_path images/TASS_YOLO_out --score_threshold 0.3 --iou_threshold 0.5 model_data/yolo.h5
 
 python3 test_yolo.py --anchors_path model_data/yolo_anchors.txt --classes_path ../DATA/gtsdb_classes.txt --test_path /Users/liangchuangu/Downloads/Movies/splited/left --output_path images/TASS_out --score_threshold 0.3 --iou_threshold 0.5 retrained_yolo.h5
+
+python3 test_yolo.py --anchors_path model_data/yolo_anchors.txt --classes_path model_data/coco_classes.txt --test_path /Users/liangchuangu/Downloads/TrainIJCNN2013/jpgs --output_path images/out_tiny --score_threshold 0.5 --iou_threshold 0.5 model_data/yolov2-tiny.h5

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,12 @@
+python3 test_yolo.py --anchors_path model_data/yolo_anchors.txt --classes_path ../DATA/gtsdb_classes.txt --test_path /Users/liangchuangu/Downloads/TrainIJCNN2013/jpgs --output_path images/out_tiny --score_threshold 0.3 --iou_threshold 0.5 retrained_tiny_yolo.h5
+
+python3 test_yolo.py --anchors_path model_data/yolo_anchors.txt --classes_path ../DATA/gtsdb_classes.txt --test_path /Users/liangchuangu/Downloads/TrainIJCNN2013/jpgs --output_path images/out --score_threshold 0.3 --iou_threshold 0.5 retrained_yolo.h5
+
+python3 test_yolo.py --anchors_path model_data/yolo_anchors.txt --classes_path ../DATA/gtsdb_classes.txt --test_path /Users/liangchuangu/Downloads/TASS/splitted_resized/left --output_path images/TASS_out --score_threshold 0.3 --iou_threshold 0.5 retrained_yolo.h5
+
+./yad2k.py yolo.cfg yolo.weights model_data/yolo.h5
+
+
+python3 test_yolo.py --anchors_path model_data/yolo_anchors.txt --classes_path model_data/coco_classes.txt --test_path /Users/liangchuangu/Downloads/TASS_jpgs --output_path images/TASS_YOLO_out --score_threshold 0.3 --iou_threshold 0.5 model_data/yolo.h5
+
+python3 test_yolo.py --anchors_path model_data/yolo_anchors.txt --classes_path ../DATA/gtsdb_classes.txt --test_path /Users/liangchuangu/Downloads/Movies/splited/left --output_path images/TASS_out --score_threshold 0.3 --iou_threshold 0.5 retrained_yolo.h5

--- a/yad2k.py
+++ b/yad2k.py
@@ -80,7 +80,7 @@ def _main(args):
     print('Loading weights.')
     weights_file = open(weights_path, 'rb')
     weights_header = np.ndarray(
-        shape=(4, ), dtype='int32', buffer=weights_file.read(16))
+        shape=(4, ), dtype='int32', buffer=weights_file.read(20))
     print('Weights Header: ', weights_header)
     # TODO: Check transpose flag when implementing fully connected layers.
     # transpose = (weight_header[0] > 1000) or (weight_header[1] > 1000)

--- a/yad2k/models/keras_darknetref.py
+++ b/yad2k/models/keras_darknetref.py
@@ -1,0 +1,59 @@
+"""Darknet19 Model Defined in Keras."""
+import functools
+from functools import partial
+
+from keras.layers import Conv2D, MaxPooling2D
+from keras.layers.advanced_activations import LeakyReLU
+from keras.layers.normalization import BatchNormalization
+from keras.models import Model
+from keras.regularizers import l2
+
+from ..utils import compose
+
+# Partial wrapper for Convolution2D with static default argument.
+_DarknetConv2D = partial(Conv2D, padding='same')
+
+
+@functools.wraps(Conv2D)
+def DarknetConv2D(*args, **kwargs):
+    """Wrapper to set Darknet weight regularizer for Convolution2D."""
+    darknet_conv_kwargs = {'kernel_regularizer': l2(5e-4)}
+    darknet_conv_kwargs.update(kwargs)
+    return _DarknetConv2D(*args, **darknet_conv_kwargs)
+
+
+def DarknetConv2D_BN_Leaky(*args, **kwargs):
+    """Darknet Convolution2D followed by BatchNormalization and LeakyReLU."""
+    no_bias_kwargs = {'use_bias': False}
+    no_bias_kwargs.update(kwargs)
+    return compose(
+        DarknetConv2D(*args, **no_bias_kwargs),
+        BatchNormalization(),
+        LeakyReLU(alpha=0.1))
+
+
+def darknetref_body():
+    """Generate first 8 conv layers of Darknet-Ref."""
+    return compose(
+        DarknetConv2D_BN_Leaky(16, (3, 3)),
+        MaxPooling2D(),
+        DarknetConv2D_BN_Leaky(32, (3, 3)),
+        MaxPooling2D(),
+        DarknetConv2D_BN_Leaky(64, (3, 3)),
+        MaxPooling2D(),
+        DarknetConv2D_BN_Leaky(128, (3, 3)),
+        MaxPooling2D(),
+        DarknetConv2D_BN_Leaky(256, (3, 3)),
+        MaxPooling2D(),
+        DarknetConv2D_BN_Leaky(512, (3, 3)),
+        MaxPooling2D(),
+        DarknetConv2D_BN_Leaky(1024, (3, 3)),
+        DarknetConv2D_BN_Leaky(512, (3, 3))
+        )
+
+def darknetref(inputs):
+    """Generate Darknet-19 model for Imagenet classification."""
+    body = darknetref_body()(inputs)
+    logits = DarknetConv2D(1000, (1, 1), activation='softmax')(body)
+    return Model(inputs, logits)
+


### PR DESCRIPTION
Hey,

I am trying to retrain tiny YOLO to predict traffic signs using gtsdb. I have finished the tiny YOLO body, but when I followed the instructions to retrain the model, I got "Incompatible shapes" in yolo_loss. Here is the command to replicate the issue. And the npz data file is shared [here](https://drive.google.com/open?id=1qmiNFD7TuKA7Sr-uITIVzx1JH8BJx1Pi), and the class file is shared [here](https://drive.google.com/open?id=1hVjuru1Mliv7H9WwHVq_vaEuxDdE0SYH). Note, there is loads of code duplication right now, but after debugging I will clean up.

retrain_tiny_yolo.py --data_path "my_dataset.npz" --classes_path "gtsdb_classes.txt"


Train on 666 samples, validate on 75 samples
Epoch 1/5
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1323, in _do_call
    return fn(*args)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1302, in _run_fn
    status, run_metadata)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/framework/errors_impl.py", line 473, in __exit__
    c_api.TF_GetCode(self.status.status))
tensorflow.python.framework.errors_impl.InvalidArgumentError: Incompatible shapes: [32,13,13,5,1] vs. [32,6,6,5,1]
	 [[Node: yolo_loss/mul_8 = Mul[T=DT_FLOAT, _device="/job:localhost/replica:0/task:0/device:CPU:0"](yolo_loss/mul_7, yolo_loss/Square_2)]]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "retrain_tiny_yolo.py", line 356, in <module>
    _main(args)
  File "retrain_tiny_yolo.py", line 77, in _main
    matching_true_boxes
  File "retrain_tiny_yolo.py", line 259, in train
    callbacks=[logging])
  File "/usr/local/lib/python3.6/site-packages/keras/engine/training.py", line 1650, in fit
    validation_steps=validation_steps)
  File "/usr/local/lib/python3.6/site-packages/keras/engine/training.py", line 1213, in _fit_loop
    outs = f(ins_batch)
  File "/usr/local/lib/python3.6/site-packages/keras/backend/tensorflow_backend.py", line 2352, in __call__
    **self.session_kwargs)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 889, in run
    run_metadata_ptr)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1120, in _run
    feed_dict_tensor, options, run_metadata)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1317, in _do_run
    options, run_metadata)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1336, in _do_call
    raise type(e)(node_def, op, message)
tensorflow.python.framework.errors_impl.InvalidArgumentError: Incompatible shapes: [32,13,13,5,1] vs. [32,6,6,5,1]
	 [[Node: yolo_loss/mul_8 = Mul[T=DT_FLOAT, _device="/job:localhost/replica:0/task:0/device:CPU:0"](yolo_loss/mul_7, yolo_loss/Square_2)]]

Caused by op 'yolo_loss/mul_8', defined at:
  File "retrain_tiny_yolo.py", line 356, in <module>
    _main(args)
  File "retrain_tiny_yolo.py", line 68, in _main
    model_body, model = create_model(anchors, class_names)
  File "retrain_tiny_yolo.py", line 224, in create_model
    detectors_mask_input, matching_boxes_input
  File "/usr/local/lib/python3.6/site-packages/keras/engine/topology.py", line 603, in __call__
    output = self.call(inputs, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/keras/layers/core.py", line 651, in call
    return self.function(inputs, **arguments)
  File "/Users/liangchuangu/Development/machine_learning/YAD2K/yad2k/models/keras_yolo.py", line 281, in yolo_loss
    K.square(1 - pred_confidence))
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/ops/math_ops.py", line 900, in binary_op_wrapper
    return func(x, y, name=name)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/ops/math_ops.py", line 1123, in _mul_dispatch
    return gen_math_ops._mul(x, y, name=name)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/ops/gen_math_ops.py", line 2821, in _mul
    "Mul", x=x, y=y, name=name)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/framework/op_def_library.py", line 787, in _apply_op_helper
    op_def=op_def)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/framework/ops.py", line 3042, in create_op
    op_def=op_def)
  File "/usr/local/lib/python3.6/site-packages/tensorflow/python/framework/ops.py", line 1521, in __init__
    self._traceback = self._graph._extract_stack()  # pylint: disable=protected-access

InvalidArgumentError (see above for traceback): Incompatible shapes: [32,13,13,5,1] vs. [32,6,6,5,1]
	 [[Node: yolo_loss/mul_8 = Mul[T=DT_FLOAT, _device="/job:localhost/replica:0/task:0/device:CPU:0"](yolo_loss/mul_7, yolo_loss/Square_2)]]