### PR TITLE
Fix "is directory" check in test_yolo.py

### DIFF
--- a/test_yolo.py
+++ b/test_yolo.py
@@ -115,11 +115,10 @@ def _main(args):
         iou_threshold=args.iou_threshold)
 
     for image_file in os.listdir(test_path):
-        try:
-            image_type = imghdr.what(os.path.join(test_path, image_file))
-            if not image_type:
-                continue
-        except IsADirectoryError:
+        if os.path.isdir(os.path.join(test_path, image_file)):
+            continue
+        image_type = imghdr.what(os.path.join(test_path, image_file))
+        if not image_type:
             continue
 
         image = Image.open(os.path.join(test_path, image_file))


### PR DESCRIPTION
I'm proposing this change because the existing implementation gave me an error like this:

```
Traceback (most recent call last):
  File "test_yolo.py", line 194, in <module>
    _main(parser.parse_args())
  File "test_yolo.py", line 119, in _main
    image_type = imghdr.what(os.path.join(test_path, image_file))
  File "C:\Users\Iver\Anaconda3\envs\yad2k\lib\imghdr.py", line 16, in what
    f = open(file, 'rb')
PermissionError: [Errno 13] Permission denied: 'images\\out'
```

Environment: Windows 10, Anaconda 3 64 bit, Python 3.6.1